### PR TITLE
feat: add yahoo finance provider support

### DIFF
--- a/cmd/calais/main.go
+++ b/cmd/calais/main.go
@@ -13,6 +13,7 @@ import (
 	"git.sr.ht/~atmosx/calais/pkg/providers"
 	"git.sr.ht/~atmosx/calais/pkg/providers/fixer"
 	"git.sr.ht/~atmosx/calais/pkg/providers/marketstack"
+	"git.sr.ht/~atmosx/calais/pkg/providers/yahoo"
 )
 
 var (
@@ -40,7 +41,8 @@ func main() {
 		os.Exit(1)
 	}
 
-	stockProvider := marketstack.New(cfg.Marketstack.Key, http.DefaultClient, logger)
+	msProvider := marketstack.New(cfg.Marketstack.Key, http.DefaultClient, logger)
+	yahooProvider := yahoo.New(http.DefaultClient, logger)
 
 	var currencyProvider providers.CurrencyProvider
 	if cfg.Fixer.Key != "" {
@@ -50,9 +52,9 @@ func main() {
 	writer := ledger.NewWriter(cfg.Ledger.PriceDB)
 
 	for _, symbol := range cfg.Marketstack.Stocks {
-		sd, err := stockProvider.FetchStock(symbol)
+		sd, err := msProvider.FetchStock(symbol)
 		if err != nil {
-			logger.Error("failed to fetch stock", "symbol", symbol, "error", err)
+			logger.Error("failed to fetch marketstack stock", "symbol", symbol, "error", err)
 			continue
 		}
 		if err := writer.Append(doctype.Record{
@@ -64,7 +66,25 @@ func main() {
 			logger.Error("failed to write stock price", "symbol", symbol, "error", err)
 			continue
 		}
-		logger.Info("wrote stock price", "symbol", sd.Symbol, "price", sd.Close, "date", sd.Date)
+		logger.Info("wrote stock price", "source", "marketstack", "symbol", sd.Symbol, "price", sd.Close)
+	}
+
+	for _, symbol := range cfg.Yahoo.Stocks {
+		sd, err := yahooProvider.FetchStock(symbol)
+		if err != nil {
+			logger.Error("failed to fetch yahoo stock", "symbol", symbol, "error", err)
+			continue
+		}
+		if err := writer.Append(doctype.Record{
+			Time:   sd.Date,
+			Symbol: sd.Symbol,
+			Price:  sd.Close,
+			Kind:   "commodity",
+		}); err != nil {
+			logger.Error("failed to write stock price", "symbol", symbol, "error", err)
+			continue
+		}
+		logger.Info("wrote stock price", "source", "yahoo", "symbol", sd.Symbol, "price", sd.Close)
 	}
 
 	if currencyProvider != nil {
@@ -83,7 +103,7 @@ func main() {
 				logger.Error("failed to write currency price", "pair", p.From+"/"+p.To, "error", err)
 				continue
 			}
-			logger.Info("wrote currency price", "pair", p.From+"/"+p.To, "rate", cd.Rate, "date", cd.Date)
+			logger.Info("wrote currency price", "pair", p.From+"/"+p.To, "rate", cd.Rate)
 		}
 	}
 }

--- a/examples/config.yaml
+++ b/examples/config.yaml
@@ -5,6 +5,11 @@ marketstack:
     - AAPL
     - MSFT
 
+# No key required
+yahoo:
+  stocks:
+    - GOOG
+
 fixer:
   key: "YOUR_FIXER_KEY"
   pairs:

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -11,6 +11,11 @@ type MarketstackConfig struct {
 	Stocks []string `yaml:"stocks"`
 }
 
+// New: Yahoo configuration struct
+type YahooConfig struct {
+	Stocks []string `yaml:"stocks"`
+}
+
 type Pair struct {
 	From string `yaml:"from"`
 	To   string `yaml:"to"`
@@ -27,6 +32,7 @@ type LedgerConfig struct {
 
 type Config struct {
 	Marketstack MarketstackConfig `yaml:"marketstack"`
+	Yahoo       YahooConfig       `yaml:"yahoo"`
 	Fixer       FixerConfig       `yaml:"fixer"`
 	Ledger      LedgerConfig      `yaml:"ledger"`
 }

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -7,12 +7,17 @@ import (
 )
 
 func TestLoadConfig_Success(t *testing.T) {
-	yaml := `
+	yamlData := `
 marketstack:
   key: "test-ms-key"
   stocks:
     - AAPL
     - MSFT
+
+yahoo:
+  stocks:
+    - MTLN
+    - GOOG
 
 fixer:
   key: "test-fixer-key"
@@ -24,7 +29,7 @@ ledger:
   price_db: "/tmp/prices.db"
 `
 	path := filepath.Join(t.TempDir(), "config.yaml")
-	if err := os.WriteFile(path, []byte(yaml), 0o600); err != nil {
+	if err := os.WriteFile(path, []byte(yamlData), 0o600); err != nil {
 		t.Fatalf("could not create temp config: %v", err)
 	}
 
@@ -33,7 +38,6 @@ ledger:
 		t.Fatalf("LoadConfig failed: %v", err)
 	}
 
-	// marketstack
 	if cfg.Marketstack.Key != "test-ms-key" {
 		t.Errorf("expected Marketstack.Key 'test-ms-key', got %q", cfg.Marketstack.Key)
 	}
@@ -41,7 +45,13 @@ ledger:
 		t.Errorf("unexpected Marketstack.Stocks: %v", cfg.Marketstack.Stocks)
 	}
 
-	// fixer
+	if len(cfg.Yahoo.Stocks) != 2 {
+		t.Errorf("expected 2 yahoo stocks, got %d", len(cfg.Yahoo.Stocks))
+	}
+	if cfg.Yahoo.Stocks[0] != "MTLN" || cfg.Yahoo.Stocks[1] != "GOOG" {
+		t.Errorf("unexpected Yahoo.Stocks: %v", cfg.Yahoo.Stocks)
+	}
+
 	if cfg.Fixer.Key != "test-fixer-key" {
 		t.Errorf("expected Fixer.Key 'test-fixer-key', got %q", cfg.Fixer.Key)
 	}
@@ -65,7 +75,7 @@ func TestLoadConfig_FileNotFound(t *testing.T) {
 }
 
 func TestLoadConfig_MalformedYAML(t *testing.T) {
-	yaml := `
+	yamlData := `
 marketstack:
   key: "test"
   stocks: [AAPL
@@ -73,7 +83,7 @@ ledger:
   price_db: "/tmp/prices.db"
 `
 	path := filepath.Join(t.TempDir(), "malformed.yaml")
-	if err := os.WriteFile(path, []byte(yaml), 0o600); err != nil {
+	if err := os.WriteFile(path, []byte(yamlData), 0o600); err != nil {
 		t.Fatalf("could not create temp config: %v", err)
 	}
 

--- a/pkg/providers/yahoo/yahoo.go
+++ b/pkg/providers/yahoo/yahoo.go
@@ -1,0 +1,120 @@
+package yahoo
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"time"
+
+	"git.sr.ht/~atmosx/calais/pkg/log"
+	"git.sr.ht/~atmosx/calais/pkg/providers"
+)
+
+const apiBaseURL = "https://query1.finance.yahoo.com/v8/finance/chart"
+
+type HTTPDoer interface {
+	Do(req *http.Request) (*http.Response, error)
+}
+
+type Client struct {
+	client HTTPDoer
+	logger *log.Logger
+}
+
+type yahooChartResponse struct {
+	Chart struct {
+		Result []struct {
+			Meta struct {
+				Symbol string `json:"symbol"`
+			} `json:"meta"`
+			Timestamp  []int64 `json:"timestamp"`
+			Indicators struct {
+				Quote []struct {
+					Close  []*float64 `json:"close"`
+					Volume []*float64 `json:"volume"`
+				} `json:"quote"`
+			} `json:"indicators"`
+		} `json:"result"`
+		Error *struct {
+			Code        string `json:"code"`
+			Description string `json:"description"`
+		} `json:"error"`
+	} `json:"chart"`
+}
+
+func New(client HTTPDoer, logger *log.Logger) *Client {
+	return &Client{
+		client: client,
+		logger: logger,
+	}
+}
+
+func (c *Client) FetchStock(symbol string) (*providers.StockData, error) {
+	url := fmt.Sprintf("%s/%s?interval=1d&range=1d", apiBaseURL, symbol)
+
+	req, err := http.NewRequest("GET", url, nil)
+	if err != nil {
+		c.logger.Error("Failed to create HTTP request", "symbol", symbol, "error", err)
+		return nil, fmt.Errorf("failed to create request for symbol %s: %w", symbol, err)
+	}
+
+	// Yahoo Finance often rejects requests without a User-Agent header.
+	req.Header.Set("User-Agent", "Mozilla/5.0 (compatible; Calais/1.0)")
+
+	resp, err := c.client.Do(req)
+	if err != nil {
+		c.logger.Error("Failed to execute HTTP request", "symbol", symbol, "error", err)
+		return nil, fmt.Errorf("failed to fetch data for symbol %s: %w", symbol, err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		c.logger.Error("Received non-OK HTTP status", "status", resp.Status, "symbol", symbol)
+		return nil, fmt.Errorf("bad response status for symbol %s: %s", symbol, resp.Status)
+	}
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		c.logger.Error("Failed to read response body", "symbol", symbol, "error", err)
+		return nil, fmt.Errorf("failed to read response for %s: %w", symbol, err)
+	}
+
+	var yahooData yahooChartResponse
+	if err := json.Unmarshal(body, &yahooData); err != nil {
+		c.logger.Error("Failed to unmarshal JSON response", "symbol", symbol, "error", err)
+		return nil, fmt.Errorf("failed to decode response for %s: %w", symbol, err)
+	}
+
+	if yahooData.Chart.Error != nil {
+		return nil, fmt.Errorf("yahoo api error: %s", yahooData.Chart.Error.Description)
+	}
+
+	if len(yahooData.Chart.Result) == 0 {
+		return nil, fmt.Errorf("no data returned for symbol %s", symbol)
+	}
+
+	result := yahooData.Chart.Result[0]
+	if len(result.Timestamp) == 0 || len(result.Indicators.Quote) == 0 {
+		return nil, fmt.Errorf("empty time series for symbol %s", symbol)
+	}
+
+	idx := len(result.Timestamp) - 1
+	quote := result.Indicators.Quote[0]
+
+	if len(quote.Close) <= idx || quote.Close[idx] == nil {
+		return nil, fmt.Errorf("missing close price for symbol %s", symbol)
+	}
+
+	var vol float64
+	if len(quote.Volume) > idx && quote.Volume[idx] != nil {
+		vol = *quote.Volume[idx]
+	}
+
+	return &providers.StockData{
+		Symbol: result.Meta.Symbol,
+		Date:   time.Unix(result.Timestamp[idx], 0),
+		Close:  *quote.Close[idx],
+		Volume: vol,
+	}, nil
+}

--- a/pkg/providers/yahoo/yahoo_test.go
+++ b/pkg/providers/yahoo/yahoo_test.go
@@ -1,0 +1,179 @@
+package yahoo
+
+import (
+	"bytes"
+	"errors"
+	"io"
+	"net/http"
+	"os"
+	"testing"
+	"time"
+
+	"git.sr.ht/~atmosx/calais/pkg/log"
+	"git.sr.ht/~atmosx/calais/pkg/providers"
+)
+
+type mockHTTPClient struct {
+	DoFunc func(req *http.Request) (*http.Response, error)
+}
+
+func (m *mockHTTPClient) Do(req *http.Request) (*http.Response, error) {
+	return m.DoFunc(req)
+}
+
+func newTestClient(fn func(req *http.Request) (*http.Response, error)) *Client {
+	logger := log.New(io.Discard, "Error")
+	return New(&mockHTTPClient{DoFunc: fn}, logger)
+}
+
+func TestFetchStock(t *testing.T) {
+	tests := []struct {
+		name        string
+		mockDoFunc  func(req *http.Request) (*http.Response, error)
+		expectError bool
+		check       func(t *testing.T, sd *providers.StockData, err error)
+	}{
+		{
+			name: "success",
+			mockDoFunc: func(req *http.Request) (*http.Response, error) {
+				jsonResp := `{
+"chart": {
+						"result": [{
+							"meta": { "symbol": "AAPL" },
+							"timestamp": [1755475200],
+							"indicators": {
+								"quote": [{
+									"close": [150.75],
+									"volume": [12345678]
+								}]
+							}
+						}],
+						"error": null
+					}
+				}`
+				return &http.Response{
+					StatusCode: http.StatusOK,
+					Body:       io.NopCloser(bytes.NewBufferString(jsonResp)),
+				}, nil
+			},
+			expectError: false,
+			check: func(t *testing.T, sd *providers.StockData, err error) {
+				if err != nil {
+					t.Fatalf("unexpected error: %v", err)
+				}
+				if sd.Symbol != "AAPL" || sd.Close != 150.75 {
+					t.Errorf("unexpected data: %+v", sd)
+				}
+				if sd.Date.Year() != 2025 || sd.Date.Month() != time.August || sd.Date.Day() != 18 {
+					t.Errorf("date mismatch: %v", sd.Date)
+				}
+			},
+		},
+		{
+			name: "http error",
+			mockDoFunc: func(req *http.Request) (*http.Response, error) {
+				return &http.Response{
+					StatusCode: http.StatusNotFound,
+					Body:       io.NopCloser(bytes.NewBufferString("not found")),
+				}, nil
+			},
+			expectError: true,
+		},
+		{
+			name: "network error",
+			mockDoFunc: func(req *http.Request) (*http.Response, error) {
+				return nil, errors.New("simulated network failure")
+			},
+			expectError: true,
+		},
+		{
+			name: "malformed JSON",
+			mockDoFunc: func(req *http.Request) (*http.Response, error) {
+				return &http.Response{
+					StatusCode: http.StatusOK,
+					Body:       io.NopCloser(bytes.NewBufferString(`{"chart": { "result": [`)),
+				}, nil
+			},
+			expectError: true,
+		},
+		{
+			name: "yahoo api error",
+			mockDoFunc: func(req *http.Request) (*http.Response, error) {
+				jsonResp := `{
+"chart": {
+						"result": null,
+						"error": {
+							"code": "Not Found",
+							"description": "Symbol not found"
+						}
+					}
+				}`
+				return &http.Response{
+					StatusCode: http.StatusOK,
+					Body:       io.NopCloser(bytes.NewBufferString(jsonResp)),
+				}, nil
+			},
+			expectError: true,
+		},
+		{
+			name: "empty data",
+			mockDoFunc: func(req *http.Request) (*http.Response, error) {
+				return &http.Response{
+					StatusCode: http.StatusOK,
+					Body:       io.NopCloser(bytes.NewBufferString(`{"chart":{"result":[]}}`)),
+				}, nil
+			},
+			expectError: true,
+		},
+		{
+			name: "empty timestamp/indicators",
+			mockDoFunc: func(req *http.Request) (*http.Response, error) {
+				jsonResp := `{
+"chart": {
+						"result": [{
+							"meta": { "symbol": "AAPL" },
+							"timestamp": [],
+							"indicators": { "quote": [] }
+						}],
+						"error": null
+					}
+				}`
+				return &http.Response{
+					StatusCode: http.StatusOK,
+					Body:       io.NopCloser(bytes.NewBufferString(jsonResp)),
+				}, nil
+			},
+			expectError: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			client := newTestClient(tt.mockDoFunc)
+			sd, err := client.FetchStock("TEST")
+			switch {
+			case tt.expectError && err == nil:
+				t.Fatal("expected an error but got none")
+			case !tt.expectError && err != nil:
+				t.Fatalf("did not expect an error: %v", err)
+			}
+			if tt.check != nil {
+				tt.check(t, sd, err)
+			}
+		})
+	}
+}
+
+func TestNew(t *testing.T) {
+	logger := log.New(os.Stdout, "Info")
+	httpClient := &http.Client{}
+
+	client := New(httpClient, logger)
+
+	if client.client != httpClient {
+		t.Error("httpClient not wired correctly")
+	}
+	if client.logger != logger {
+		t.Error("logger not wired correctly")
+	}
+}


### PR DESCRIPTION
This adds a new stock data provider using the unofficial public Yahoo Finance API (v8/finance/chart). Unlike Marketstack, this provider does not require an API key.

Changes:
- Add `pkg/providers/yahoo`: new client implementation using the public chart endpoint.
- Update `internal/config`: add `yahoo` configuration section.
- Update `cmd/calais`: wire up the Yahoo provider in the main loop.
- Add unit tests for the new provider and config parsing.

The new provider handles null values in the JSON response safely and converts Unix timestamps to native Go time types.