### PR TITLE
feat: pushover notifications

### DIFF
--- a/cmd/calais/main.go
+++ b/cmd/calais/main.go
@@ -13,6 +13,7 @@ import (
 	"git.sr.ht/~atmosx/calais/pkg/providers"
 	"git.sr.ht/~atmosx/calais/pkg/providers/fixer"
 	"git.sr.ht/~atmosx/calais/pkg/providers/marketstack"
+	"git.sr.ht/~atmosx/calais/pkg/providers/pushover"
 	"git.sr.ht/~atmosx/calais/pkg/providers/yahoo"
 )
 
@@ -41,6 +42,51 @@ func main() {
 		os.Exit(1)
 	}
 
+	// Initialize Notifiers (Pushover)
+	// We use the Notifier interface so this list can hold email providers in the future.
+	var notifiers []pushover.Notifier
+
+	// Check if Pushover config exists and initialize providers
+	// Note: This assumes you have added `Pushover Pushover yaml:"pushover"` to your main Config struct.
+	for _, pConf := range cfg.Pushover.Config {
+		// Create a new Pushover client using the configuration
+		n := pushover.New(pConf.Token, pConf.Recipient, http.DefaultClient)
+		notifiers = append(notifiers, n)
+	}
+
+	// Helper function to check rules and send notifications
+	checkAndNotify := func(symbol string, currentPrice float64) {
+		for _, rule := range cfg.Pushover.Notify {
+			// Notify if the symbol matches and price meets the target (>=)
+			if rule.Stock == symbol && currentPrice >= rule.Price {
+				msg := fmt.Sprintf("Price Alert: %s has reached %.2f (Target: %.2f)", symbol, currentPrice, rule.Price)
+
+				for _, n := range notifiers {
+					if err := n.Send("Stock Alert", msg); err != nil {
+						logger.Error("failed to send notification", "type", "pushover", "error", err)
+					} else {
+						logger.Info("notification sent", "symbol", symbol, "price", currentPrice)
+					}
+				}
+			}
+		}
+	}
+
+	checkAndNotifyCurrency := func(from, to string, currentRate float64) {
+		for _, rule := range cfg.Pushover.NotifyCurrency {
+			if rule.From == from && rule.To == to && currentRate >= rule.Price {
+				msg := fmt.Sprintf("Currency Alert: %s/%s has reached %.4f (Target: %.4f)", from, to, currentRate, rule.Price)
+				for _, n := range notifiers {
+					if err := n.Send("Currency Alert", msg); err != nil {
+						logger.Error("failed to send currency notification", "type", "pushover", "error", err)
+					} else {
+						logger.Info("currency notification sent", "pair", from+"/"+to, "rate", currentRate)
+					}
+				}
+			}
+		}
+	}
+
 	msProvider := marketstack.New(cfg.Marketstack.Key, http.DefaultClient, logger)
 	yahooProvider := yahoo.New(http.DefaultClient, logger)
 
@@ -51,6 +97,7 @@ func main() {
 
 	writer := ledger.NewWriter(cfg.Ledger.PriceDB)
 
+	// Process Marketstack Stocks
 	for _, symbol := range cfg.Marketstack.Stocks {
 		sd, err := msProvider.FetchStock(symbol)
 		if err != nil {
@@ -67,8 +114,12 @@ func main() {
 			continue
 		}
 		logger.Info("wrote stock price", "source", "marketstack", "symbol", sd.Symbol, "price", sd.Close)
+
+		// Check for notifications
+		checkAndNotify(sd.Symbol, sd.Close)
 	}
 
+	// Process Yahoo Stocks
 	for _, symbol := range cfg.Yahoo.Stocks {
 		sd, err := yahooProvider.FetchStock(symbol)
 		if err != nil {
@@ -85,8 +136,12 @@ func main() {
 			continue
 		}
 		logger.Info("wrote stock price", "source", "yahoo", "symbol", sd.Symbol, "price", sd.Close)
+
+		// Check for notifications
+		checkAndNotify(sd.Symbol, sd.Close)
 	}
 
+	// Process Currencies
 	if currencyProvider != nil {
 		for _, p := range cfg.Fixer.Pairs {
 			cd, err := currencyProvider.FetchCurrency(p.From, p.To)
@@ -96,7 +151,7 @@ func main() {
 			}
 			if err := writer.Append(doctype.Record{
 				Time:   cd.Date,
-				Symbol: cd.From,
+				Symbol: cd.From, // Ideally this might record the pair, e.g., "EUR/USD" depending on your doctype logic
 				Price:  cd.Rate,
 				Kind:   "currency",
 			}); err != nil {
@@ -104,6 +159,9 @@ func main() {
 				continue
 			}
 			logger.Info("wrote currency price", "pair", p.From+"/"+p.To, "rate", cd.Rate)
+
+			// Check currency notifications
+			checkAndNotifyCurrency(cd.From, cd.To, cd.Rate)
 		}
 	}
 }

--- a/examples/config.yaml
+++ b/examples/config.yaml
@@ -1,11 +1,9 @@
-# stock pricing
 marketstack:
   key: "YOUR_MARKETSTACK_KEY"
   stocks:
     - AAPL
     - MSFT
 
-# No key required
 yahoo:
   stocks:
     - GOOG
@@ -18,3 +16,12 @@ fixer:
 
 ledger:
    price_db: "/tmp/prices.db"
+
+pushover:
+  config:
+    token: PUSHOVER_APP_TOKEN
+    recipient: PUSHOVER_RECIPIENT_TOKEN
+  notify:
+    - { stock: "GOOG", price: 450 }
+  notify_currency:
+    - { from: "EUR", to: "USD", price: 1.08 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -11,7 +11,6 @@ type MarketstackConfig struct {
 	Stocks []string `yaml:"stocks"`
 }
 
-// New: Yahoo configuration struct
 type YahooConfig struct {
 	Stocks []string `yaml:"stocks"`
 }
@@ -30,11 +29,35 @@ type LedgerConfig struct {
 	PriceDB string `yaml:"price_db"`
 }
 
+// PushoverConfig holds the credentials for a single Pushover account.
+type PushoverConfig struct {
+	Token     string `yaml:"token"`
+	Recipient string `yaml:"recipient"`
+}
+
+type Notification struct {
+	Stock string  `yaml:"stock"`
+	Price float64 `yaml:"price"`
+}
+
+type CurrencyNotification struct {
+	From  string  `yaml:"from"`
+	To    string  `yaml:"to"`
+	Price float64 `yaml:"price"`
+}
+
+type Pushover struct {
+	Config         []PushoverConfig       `yaml:"config"`
+	Notify         []Notification         `yaml:"notify"`
+	NotifyCurrency []CurrencyNotification `yaml:"notify_currency"`
+}
+
 type Config struct {
 	Marketstack MarketstackConfig `yaml:"marketstack"`
 	Yahoo       YahooConfig       `yaml:"yahoo"`
 	Fixer       FixerConfig       `yaml:"fixer"`
 	Ledger      LedgerConfig      `yaml:"ledger"`
+	Pushover    Pushover          `yaml:"pushover"`
 }
 
 func LoadConfig(path string) (*Config, error) {

--- a/pkg/providers/provider.go
+++ b/pkg/providers/provider.go
@@ -2,7 +2,6 @@ package providers
 
 import "time"
 
-// StockData represents a single stock end-of-day record.
 type StockData struct {
 	Symbol string
 	Date   time.Time
@@ -10,7 +9,6 @@ type StockData struct {
 	Volume float64
 }
 
-// CurrencyData represents a single currency pair rate.
 type CurrencyData struct {
 	From string
 	To   string
@@ -18,7 +16,6 @@ type CurrencyData struct {
 	Date time.Time
 }
 
-// Provider interfaces
 type StockProvider interface {
 	FetchStock(symbol string) (*StockData, error)
 }

--- a/pkg/providers/provider_test.go
+++ b/pkg/providers/provider_test.go
@@ -5,7 +5,6 @@ import (
 	"time"
 )
 
-// TestStockData ensures the StockData struct can be created and its fields assigned correctly.
 func TestStockData(t *testing.T) {
 	date := time.Now()
 	sd := StockData{

--- a/pkg/providers/pushover/pushover.go
+++ b/pkg/providers/pushover/pushover.go
@@ -1,0 +1,53 @@
+package pushover
+
+import (
+	"fmt"
+	"net/http"
+	"net/url"
+)
+
+const (
+	pushoverAPIURL = "https://api.pushover.net/1/messages.json"
+)
+
+type Notifier interface {
+	Send(title, message string) error
+}
+
+type Pushover struct {
+	token     string
+	recipient string
+	client    *http.Client
+}
+
+func New(token, recipient string, client *http.Client) *Pushover {
+	return &Pushover{
+		token:     token,
+		recipient: recipient,
+		client:    client,
+	}
+}
+
+func (p *Pushover) Send(title, message string) error {
+	if p.token == "" || p.recipient == "" {
+		return fmt.Errorf("pushover token or recipient is missing")
+	}
+
+	data := url.Values{}
+	data.Set("token", p.token)
+	data.Set("user", p.recipient)
+	data.Set("title", title)
+	data.Set("message", message)
+
+	resp, err := p.client.PostForm(pushoverAPIURL, data)
+	if err != nil {
+		return fmt.Errorf("failed to send pushover request: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("pushover api returned non-200 status: %s", resp.Status)
+	}
+
+	return nil
+}

--- a/pkg/providers/pushover/pushover_test.go
+++ b/pkg/providers/pushover/pushover_test.go
@@ -1,0 +1,94 @@
+package pushover
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+)
+
+func TestSend(t *testing.T) {
+	// 1. Mock the Pushover API server
+	mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Verify the request method and path
+		if r.Method != http.MethodPost {
+			t.Errorf("Expected POST request, got %s", r.Method)
+		}
+		if r.URL.Path != "/1/messages.json" {
+			t.Errorf("Expected path /1/messages.json, got %s", r.URL.Path)
+		}
+
+		// Verify that the necessary form values are sent
+		if err := r.ParseForm(); err != nil {
+			t.Fatal(err)
+		}
+		if r.FormValue("token") != "test-token" {
+			t.Errorf("Expected token 'test-token', got %s", r.FormValue("token"))
+		}
+		if r.FormValue("user") != "test-recipient" {
+			t.Errorf("Expected user 'test-recipient', got %s", r.FormValue("user"))
+		}
+		if r.FormValue("message") != "Hello World" {
+			t.Errorf("Expected message 'Hello World', got %s", r.FormValue("message"))
+		}
+
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer mockServer.Close()
+
+	// Note: In a real scenario, we cannot easily change the const pushoverAPIURL.
+	// However, for unit testing structs that accept a base URL or using a custom Transport
+	// is usually preferred. Since the requested package structure is simple and the URL is const,
+	// we will intercept the request using a custom Transport in the client to route
+	// traffic to our mock server.
+
+	client := &http.Client{
+		Transport: &testTransport{
+			Transport: http.DefaultTransport,
+			URL:       mockServer.URL,
+		},
+	}
+
+	// 2. Initialize the provider
+	p := New("test-token", "test-recipient", client)
+
+	// 3. Test sending a notification
+	err := p.Send("Test Title", "Hello World")
+	if err != nil {
+		t.Fatalf("Expected no error, got %v", err)
+	}
+}
+
+func TestSend_Error(t *testing.T) {
+	mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusBadRequest) // Simulate API error
+	}))
+	defer mockServer.Close()
+
+	client := &http.Client{
+		Transport: &testTransport{
+			Transport: http.DefaultTransport,
+			URL:       mockServer.URL,
+		},
+	}
+
+	p := New("test-token", "test-recipient", client)
+
+	err := p.Send("Test", "Fail")
+	if err == nil {
+		t.Fatal("Expected error due to non-200 status, got nil")
+	}
+}
+
+// testTransport intercepts requests and rewrites the scheme and host to the mock server
+type testTransport struct {
+	Transport http.RoundTripper
+	URL       string
+}
+
+func (t *testTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	u, _ := url.Parse(t.URL)
+	req.URL.Scheme = u.Scheme
+	req.URL.Host = u.Host
+	return t.Transport.RoundTrip(req)
+}


### PR DESCRIPTION
## Description

Lets implement the pushover notification. This implementation adds support for stock price notification but also
currency notification. However, the currency notifications work only when EUR-to-USD is calculated and doesn't support
the _negative_ scenario (notify when price goes bellow X, instead of surpasses X).
